### PR TITLE
Add OpenRouter provider

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -181,6 +181,9 @@ MEMORY_BACKUP_INTERVAL=3600000
 # Optional: API Keys
 GITHUB_TOKEN=your_github_token
 OPENAI_API_KEY=your_openai_key
+OPENROUTER_API_KEY=your_openrouter_key
+# Optional custom API URL
+# OPENROUTER_API_URL=https://openrouter.ai/api/v1
 ```
 
 ### 2. Shell Configuration

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -13,6 +13,7 @@ export { OpenAIProvider } from './openai-provider.js';
 export { GoogleProvider } from './google-provider.js';
 export { CohereProvider } from './cohere-provider.js';
 export { OllamaProvider } from './ollama-provider.js';
+export { OpenRouterProvider } from './openrouter-provider.js';
 
 // Export manager
 export { ProviderManager, ProviderManagerConfig } from './provider-manager.js';

--- a/src/providers/openrouter-provider.ts
+++ b/src/providers/openrouter-provider.ts
@@ -1,0 +1,68 @@
+import { OpenAIProvider } from './openai-provider.js';
+import {
+  LLMProvider,
+  ProviderCapabilities,
+  AuthenticationError,
+} from './types.js';
+
+/**
+ * OpenRouter Provider
+ * Uses OpenAI-compatible API endpoints provided by OpenRouter
+ */
+export class OpenRouterProvider extends OpenAIProvider {
+  readonly name: LLMProvider = 'openrouter';
+
+  readonly capabilities: ProviderCapabilities = {
+    supportedModels: [
+      'qwen/qwen3-235b-a22b-thinking-2507',
+      'qwen/qwen3-coder:free',
+      'moonshotai/kimi-k2',
+      'moonshotai/kimi-k2:free',
+      'google/gemini-2.5-pro',
+    ],
+    maxContextLength: {
+      'qwen/qwen3-235b-a22b-thinking-2507': 32768,
+      'qwen/qwen3-coder:free': 32768,
+      'moonshotai/kimi-k2': 32768,
+      'moonshotai/kimi-k2:free': 32768,
+      'google/gemini-2.5-pro': 32768,
+    } as Record<string, number>,
+    maxOutputTokens: {
+      'qwen/qwen3-235b-a22b-thinking-2507': 4096,
+      'qwen/qwen3-coder:free': 4096,
+      'moonshotai/kimi-k2': 4096,
+      'moonshotai/kimi-k2:free': 4096,
+      'google/gemini-2.5-pro': 4096,
+    } as Record<string, number>,
+    supportsStreaming: true,
+    supportsFunctionCalling: true,
+    supportsSystemMessages: true,
+    supportsVision: true,
+    supportsAudio: false,
+    supportsTools: true,
+    supportsFineTuning: false,
+    supportsEmbeddings: false,
+    supportsLogprobs: false,
+    supportsBatching: true,
+  };
+
+  // Override initialization to use OpenRouter base URL and headers
+  protected async doInitialize(): Promise<void> {
+    if (!this.config.apiKey) {
+      throw new AuthenticationError('OpenRouter API key is required', 'openrouter');
+    }
+
+    (this as any).baseUrl = this.config.apiUrl || 'https://openrouter.ai/api/v1';
+    (this as any).headers = {
+      Authorization: `Bearer ${this.config.apiKey}`,
+      'Content-Type': 'application/json',
+    } as Record<string, string>;
+
+    if (this.config.providerOptions?.referer) {
+      (this as any).headers['HTTP-Referer'] = this.config.providerOptions.referer;
+    }
+    if (this.config.providerOptions?.title) {
+      (this as any).headers['X-Title'] = this.config.providerOptions.title;
+    }
+  }
+}

--- a/src/providers/provider-manager.ts
+++ b/src/providers/provider-manager.ts
@@ -35,6 +35,7 @@ import { OpenAIProvider } from './openai-provider.js';
 import { GoogleProvider } from './google-provider.js';
 import { CohereProvider } from './cohere-provider.js';
 import { OllamaProvider } from './ollama-provider.js';
+import { OpenRouterProvider } from './openrouter-provider.js';
 
 export interface ProviderManagerConfig {
   providers: Record<LLMProvider, LLMProviderConfig>;
@@ -129,6 +130,9 @@ export class ProviderManager extends EventEmitter {
           break;
         case 'ollama':
           provider = new OllamaProvider(providerOptions);
+          break;
+        case 'openrouter':
+          provider = new OpenRouterProvider(providerOptions);
           break;
         default:
           this.logger.warn(`Unknown provider: ${name}`);

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -7,12 +7,13 @@ import { EventEmitter } from 'events';
 
 // ===== PROVIDER TYPES =====
 
-export type LLMProvider = 
+export type LLMProvider =
   | 'openai'
   | 'anthropic'
   | 'google'
   | 'cohere'
   | 'ollama'
+  | 'openrouter'
   | 'llama-cpp'
   | 'custom';
 
@@ -47,6 +48,12 @@ export type LLMModel =
   | 'llama-2-70b'
   | 'mistral-7b'
   | 'mixtral-8x7b'
+  // OpenRouter Models
+  | 'qwen/qwen3-235b-a22b-thinking-2507'
+  | 'qwen/qwen3-coder:free'
+  | 'moonshotai/kimi-k2'
+  | 'moonshotai/kimi-k2:free'
+  | 'google/gemini-2.5-pro'
   | 'custom-model';
 
 // ===== BASE INTERFACES =====

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -55,6 +55,18 @@ export function getDefaultProviderConfig(): ProviderManagerConfig {
         timeout: 60000,
         retryAttempts: 3,
       },
+      openrouter: {
+        provider: 'openrouter',
+        apiKey: process.env.OPENROUTER_API_KEY,
+        apiUrl: process.env.OPENROUTER_API_URL || 'https://openrouter.ai/api/v1',
+        model: 'google/gemini-2.5-pro',
+        temperature: 0.7,
+        maxTokens: 4096,
+        enableStreaming: true,
+        enableCaching: true,
+        timeout: 60000,
+        retryAttempts: 3,
+      },
       google: {
         provider: 'google',
         apiKey: process.env.GOOGLE_AI_API_KEY,
@@ -123,24 +135,24 @@ function getDefaultFallbackStrategy(): FallbackStrategy {
     rules: [
       {
         condition: 'rate_limit',
-        fallbackProviders: ['openai', 'google', 'cohere', 'ollama'],
+        fallbackProviders: ['openai', 'openrouter', 'google', 'cohere', 'ollama'],
         retryOriginal: true,
         retryDelay: 60000, // 1 minute
       },
       {
         condition: 'unavailable',
-        fallbackProviders: ['openai', 'google', 'anthropic', 'cohere'],
+        fallbackProviders: ['openai', 'openrouter', 'google', 'anthropic', 'cohere'],
         retryOriginal: true,
         retryDelay: 30000, // 30 seconds
       },
       {
         condition: 'timeout',
-        fallbackProviders: ['anthropic', 'openai', 'cohere'],
+        fallbackProviders: ['anthropic', 'openai', 'openrouter', 'cohere'],
         retryOriginal: false,
       },
       {
         condition: 'cost',
-        fallbackProviders: ['ollama', 'cohere', 'google'],
+        fallbackProviders: ['ollama', 'cohere', 'google', 'openrouter'],
         retryOriginal: false,
       },
       {


### PR DESCRIPTION
## Summary
- implement `OpenRouterProvider` to access OpenRouter-compatible API endpoints
- add supported OpenRouter models
- register provider in provider manager and exports
- extend default config with OPENROUTER variables and update fallback rules
- document OPENROUTER env vars in setup guide

## Testing
- `npm install`
- `npm test` *(fails: 'Exceeded timeout of 30000 ms for a test...' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6886ec6c0fa0832fb2b86dcf75e1b5b7